### PR TITLE
Updated Hashids version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.x",
-        "hashids/hashids": "0.3.x"
+        "hashids/hashids": "1.0.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Version 1.0.0 was tagged and it can't find 0.3.@dev anymore, causing the package to fail.
