### PR TITLE
Allow optional custom salt

### DIFF
--- a/src/Mitch/Hashids/HashidsServiceProvider.php
+++ b/src/Mitch/Hashids/HashidsServiceProvider.php
@@ -30,7 +30,7 @@ class HashidsServiceProvider extends ServiceProvider
 	{
 		$this->app->bind('Hashids\Hashids', function ($app) {
 			return new Hashids(
-				$app['config']['app.key'],
+				isset($app['config']['hashids::salt']) ? $app['config']['hashids::salt'] : $app['config']['app.key'],
 				$app['config']['hashids::length'],
 				$app['config']['hashids::alphabet']
 			);


### PR DESCRIPTION
Because I'm using this package in conjunction with the JS version, on the client side, I need to have matching salts but don't wish to expose my app's secret key to the world. This will now look for a package config specific salt before falling back to the app key.

Also mentioned in #21.
